### PR TITLE
Update clojars link

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@ Heavily influenced by
 
 Add the following to your =project.clj=:
 
-=[com.yetanalytics/ring-etag-middleware "0.1.0-SNAPSHOT"]=
+=[com.yetanalytics/ring-etag-middleware "0.1.1"]=
 
 In your handler,
 


### PR DESCRIPTION
The `project.clj` link provided did not work. However, you have uploaded a specific version to Clojars.

Kudos on the readme in org-mode - I do hope more and more people use that(;
